### PR TITLE
No C++ 11 ABI for the custom schema

### DIFF
--- a/plugins/custom_schemas_with_python_bindings/compiling_the_schema/CMakeLists.txt
+++ b/plugins/custom_schemas_with_python_bindings/compiling_the_schema/CMakeLists.txt
@@ -8,5 +8,6 @@ set(CMAKE_INSTALL_PREFIX "./install" CACHE PATH "..." FORCE)
 # 3. Boilerplate
 set(USDPLUGIN_NAME testout)
 find_package(PythonLibs 2.7 REQUIRED)  # Needed for `PYTHON_INCLUDE_PATH`
+add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 
 add_subdirectory(src)


### PR DESCRIPTION
The error documented in the [troubleshooting build issues](https://github.com/ColinKennedy/USD-Cookbook/tree/master/plugins/custom_schemas_with_python_bindings/compiling_the_schema#troubleshooting-build-issues) section is caused by building with a compiler that use the C++11 ABI by default against a USD distribution that does not use it. At the time of writing, the NVidia build for CentOS does not compile with the C++11 ABI.

```
$ c++filt _ZN32pxrInternal_v0_19__pxrReserved__6TfType7DeclareERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
pxrInternal_v0_19__pxrReserved__::TfType::Declare(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
```

Check `std::string`: it's an `std::__cxx11::basic_string`, meaning that `Tf` has not been compiled with the C++-11 ABI.

This patch ensure the C++ABI is not used while compiling the custom schema.